### PR TITLE
Really small fixes in some Shell script utilities.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
 cmake --build build -j`nproc`

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
 cmake --build build -j`getconf _NPROCESSORS_ONLN`
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
-cmake --build build -j`nproc`
+cmake --build build -j`getconf _NPROCESSORS_ONLN`
 
 cp build/rimboar .

--- a/clean.sh
+++ b/clean.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 ls -A | git check-ignore --stdin | xargs rm -rf

--- a/init.sh
+++ b/init.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # install vcpkg
 git clone https://github.com/Microsoft/vcpkg.git

--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # install vcpkg
 git clone https://github.com/Microsoft/vcpkg.git
 ./vcpkg/bootstrap-vcpkg.sh --disableMetrics


### PR DESCRIPTION
## fix: Use ``#!/usr/bin/env bash`` for portability.

Not all Linux distributions use GNU Bourne Again-Shell per default and/or present at ``/usr/bin``, so using ``env`` for finding it is the best way.

## fix: Use ``getconf _NPROCESSORS_ONLN`` instead of GNU's ``nproc``.

Not all Linux distributions use GNU coreutilities per default, so it may doesn't have ``nproc``(1) at ``$PATH``. Use ``getconf``(1) to get the number of processors, since it's more portable between Linux-based systems.

## fix: Exit on error.