### PR TITLE
chore: Line breaks at conditionals, also use the ``>`` macro instead …

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,9 +5,11 @@ source scripts/any_newer_than.sh
 
 test_build_type="Debug"
 
-if !([ -e "build" ]) || [ $test_build_type != "$(cat build/BUILD_TYPE)" ] || (any_newer_than build/test_rimboar src CMakeLists.txt build.sh test.sh); then
+if !([ -e "build" ]) \
+    || [ $test_build_type != "$(cat build/BUILD_TYPE)" ] \
+    || (any_newer_than build/test_rimboar src CMakeLists.txt build.sh test.sh); then
     ./scripts/build.sh $test_build_type tests
-    touch build/test_rimboar
+    > build/test_rimboar
 fi
 
 ./build/test_rimboar


### PR DESCRIPTION
…of the ``touch``(1) command

The ``>`` is faster (and considered more "correct") than ``touch`` when creating files.
